### PR TITLE
Change project id detection, try cli args, package json data on cwd, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![npm](https://nodei.co/npm/changelog-maker.png?downloads=true&downloadRank=true)](https://nodei.co/npm/changelog-maker/)
 [![npm](https://nodei.co/npm-dl/changelog-maker.png?months=6&height=3)](https://nodei.co/npm/changelog-maker/)
 
-***Note: changelog-maker can currently only be run with [io.js](https://iojs.org/) installed.***
-
 ## Eh?
 
 **changelog-maker** is a formalisation of the [io.js](https://github.com/nodejs/io.js) CHANGELOG.md entry process but flexible enough to be used on other repositories.
@@ -27,7 +25,7 @@ Each commit will come out something like this (on one line):
 
 Note:
 
-* When running `changelog-maker` on the command-line, the default GitHub repo is nodejs/io.js, you can change this by supplying the user/org as the first argument and project as the second. e.g `changelog-maker joyent node`.
+* When running `changelog-maker` on the command-line, the default GitHub repo is computed from the `package.json` that exists on `cwd`, otherwise fallback to `nodejs/io.js`, you can change this by supplying the user/org as the first argument and project as the second. e.g `changelog-maker joyent node`.
 * Commit links will go to the assumed repo (default: nodejs/io.js)
 * If a commit summary starts with a word, followed by a `:`, this is treated as a special label and rendered in bold
 * Commits that have `semver*` labels on the pull request referred to in their `PR-URL` have those labels printed out at the start of the summary, in bold, upper cased.
@@ -49,7 +47,9 @@ $ npm i changelog-maker -g
 **`changelog-maker [--simple] [--group] [--start-ref=<ref>] [--end-ref=<ref>] [github-user[, github-project]]`**
 
 * `github-user` and `github-project` should point to the GitHub repository that can be used to find the `PR-URL` data if just an issue number is provided and will also impact how the PR-URL issue numbers are displayed
-* `--simple` will print a simple form, not with additional Markdown cruft
+* `--quiet` do not print to `process.stdout`
+* `--all` process all commits since beginning, instead of last tag.
+* `--simple` will print a simple form, without additional Markdown cruft
 * `--group` will reorder commits so that they are listed in groups where the `xyz:` prefix of the commit message defines the group. Commits are listed in original order _within_ group.
 * `--start-ref=<ref>` will use the given git `<ref>` as a starting point rather than the _last tag_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name. If you specify a `--start-ref` argument the commit log will not be pruned so that version commits and `working on <version>` commits are left in the list.
 * `--end-ref=<ref>` will use the given git `<ref>` as a end-point rather than the _now_. The `<ref>` can be anything commit-ish including a commit sha, tag, branch name.

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -1,31 +1,48 @@
 #!/usr/bin/env node
 
-const gitcmd        = 'git log --pretty=full --since="{{sincecmd}}" --until="{{untilcmd}}"'
-    , commitdatecmd = '$(git show -s --format=%cd `{{refcmd}}`)'
-    , untilcmd      = ''
-    , refcmd        = 'git rev-list --max-count=1 {{ref}}'
-    , defaultRef    = '--tags=v*.*.*'
-
-
 const spawn    = require('child_process').spawn
     , bl       = require('bl')
     , split2   = require('split2')
     , list     = require('list-stream')
     , after    = require('after')
+    , fs       = require('fs')
+    , path     = require('path')
     , ghauth   = require('ghauth')
     , ghissues = require('ghissues')
     , chalk    = require('chalk')
-    , argv     = require('minimist')(process.argv.slice(2))
-    , tsml     = require('tsml')
-
+    , pkgtoId  = require('pkg-to-id')
     , commitStream = require('./commit-stream')
 
-    , ghUser        = argv._[0] || 'nodejs'
-    , ghProject     = argv._[1] || 'io.js'
+    , argv     = require('minimist')(process.argv.slice(2))
+
+    , quiet    = argv.quiet || argv.q || false
+
+    , pkg      = require('./package.json')
+    , debug    = require('debug')(pkg.name)
+
+    , cwd      = process.cwd()
+    , pkgFile  = path.join(cwd, 'package.json')
+    , pkgData  = fs.existsSync(pkgFile) ? require(pkgFile) : {}
+    , pkgId    = pkgtoId(pkgData)
+
+    , ghId     = {
+          user: argv._[0] || pkgId.user || 'nodejs'
+        , name: argv._[1] || pkgId.name || 'io.js'
+      }
     , authOptions   = {
           configName : 'changelog-maker'
         , scopes     : ['repo']
       }
+
+const gitcmd        = 'git log --pretty=full --since="{{sincecmd}}" --until="{{untilcmd}}"'
+    , commitdatecmd = '$(git show -s --format=%cd `{{refcmd}}`)'
+    , untilcmd      = ''
+    , refcmd        = argv.a || argv.all ? 'git rev-list --max-parents=0 HEAD' : 'git rev-list --max-count=1 {{ref}}'
+    , defaultRef    = '--tags=v*.*.* 2> /dev/null ' +
+    '|| git rev-list --max-count=1 --tags=*.*.* 2> /dev/null ' +
+    '|| git rev-list --max-count=1 HEAD'
+
+debug(ghId)
 
 function replace (s, m) {
   Object.keys(m).forEach(function (k) {
@@ -37,6 +54,8 @@ function replace (s, m) {
 
 function organiseCommits (list) {
   if (argv['start-ref'])
+    return list
+  else if (argv.a || argv.all)
     return list
 
   // filter commits to those _before_ 'working on ...'
@@ -72,7 +91,7 @@ function commitTags (list, callback) {
     sublist.forEach(function (commit) {
       function onFetch (err, issue) {
         if (err) {
-          console.error(`Error fetching issue #${commit.ghIssue}: ${err.message}`)
+          console.error('Error fetching issue #%s: %s', commit.ghIssue, err.message );
           return done()
         }
 
@@ -94,32 +113,23 @@ var revertRe = /^revert\s+"?/i
   , groupRe  = /^((:?\w|\-|,|, )+):\s*/i
 
 function commitToGroup (commit) {
-  var summary = commit.summary.replace(revertRe, '')
+  var summary = (commit.summary || '').replace(revertRe, '')
     , m       = summary.match(groupRe)
 
   return m && m[1]
 }
 
 
-function cleanMarkdown (txt) {
-  // just escape '[' & ']'
-  return txt.replace(/([\[\]])/g, '\\$1')
-}
-
-
 function toStringSimple (data) {
-  var s = tsml`
-
-    * [${data.sha.substr(0, 10)}] - 
-    ${data.semver.length ? '(' + data.semver.join(', ').toUpperCase() + ') ' : ''}
-    ${data.revert ? 'Revert "' : ''}
-    ${data.group ? data.group + ': ' : ''}
-    ${data.summary}
-    ${data.revert ? '"' : ''} 
-    ${data.author ? '(' + data.author + ') ' : ''}
-    ${data.pr}
-
-  `
+  var s = ''
+  s += '* [' + data.sha.substr(0, 10) + '] - '
+  s += (data.semver || []).length ? '(' + data.semver.join(', ').toUpperCase() + ') ' : ''
+  s += data.revert ? 'Revert "' : ''
+  s += data.group ? data.group + ': ' : ''
+  s += data.summary
+  s += data.revert ? '"' : '' + ' '
+  s += data.author ? '(' + data.author + ') ' : ''
+  s += data.pr ?  data.pr  : ''
 
   return data.semver.length
       ? chalk.green(chalk.bold(s))
@@ -130,18 +140,15 @@ function toStringSimple (data) {
 
 
 function toStringMarkdown (data) {
-  var s = tsml`
-
-    * [[\`${data.sha.substr(0, 10)}\`](${data.shaUrl})] - 
-    ${data.semver.length ? '**(' + data.semver.join(', ').toUpperCase() + ')** ' : ''}
-    ${data.revert ? '***Revert*** "' : ''}
-    ${data.group ? '**' + data.group + '**: ' : ''}
-    ${cleanMarkdown(data.summary)}
-    ${data.revert ? '"' : ''} 
-    ${data.author ? '(' + data.author + ') ' : ''}
-    ${data.pr ? '[' + data.pr + '](' + data.prUrl + ')' : ''}
-
-  `
+  var s = ''
+  s += '* [[' + data.sha.substr(0, 10) + '](' + data.shaUrl + ') - '
+  s += (data.semver || []).length ? '(' + data.semver.join(', ').toUpperCase() + ') ' : ''
+  s += data.revert ? 'Revert "' : ''
+  s += data.group ? data.group + ': ' : ''
+  s += data.summary
+  s += data.revert ? '"' : '' + ' '
+  s += data.author ? '(' + data.author + ') ' : ''
+  s += data.pr ?  data.pr  : ''
 
   return data.semver.length
       ? chalk.green(chalk.bold(s))
@@ -152,17 +159,19 @@ function toStringMarkdown (data) {
 
 
 function commitToOutput (commit) {
-  var data       = {}
-    , prUrlMatch = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^\/]+\/[^\/]+)\/\w+\/\d+$/i)
+  var data        = {}
+    , prUrlMatch  = commit.prUrl && commit.prUrl.match(/^https?:\/\/.+\/([^\/]+\/[^\/]+)\/\w+\/\d+$/i)
+    , urlHash     = '#'+commit.ghIssue || commit.prUrl
+    , ghUrl       = ghId.user + '/' + ghId.name
 
   data.sha     = commit.sha
-  data.shaUrl  = `https://github.com/${ghUser}/${ghProject}/commit/${commit.sha.substr(0,10)}`
+  data.shaUrl  = 'https://github.com/' + ghUrl + '/commit/' + commit.sha.substr(0,10)
   data.semver  = commit.labels && commit.labels.filter(function (l) { return l.indexOf('semver') > -1 }) || false
   data.revert  = revertRe.test(commit.summary)
   data.group   = commitToGroup(commit) || ''
-  data.summary = commit.summary.replace(revertRe, '').replace(/"$/, '').replace(groupRe, '')
+  data.summary = (commit.summary && commit.summary.replace(revertRe, '').replace(/"$/, '').replace(groupRe, '')) || ''
   data.author  = (commit.author && commit.author.name) || ''
-  data.pr      = prUrlMatch && `${prUrlMatch[1] != ghUser + '/' + ghProject ? prUrlMatch[1] : ''}#${commit.ghIssue || commit.prUrl}`
+  data.pr      = prUrlMatch && ((prUrlMatch[1] != ghUrl ? prUrlMatch[1] : '') + urlHash)
   data.prUrl   = prUrlMatch && commit.prUrl
 
   return (argv.simple ? toStringSimple : toStringMarkdown)(data)
@@ -185,7 +194,7 @@ function groupCommits (list) {
 
 
 function printCommits (list) {
-  var out = `${list.join('\n')} \n`
+  var out = list.join('\n') + '\n'
 
   if (!process.stdout.isTTY)
     out = chalk.stripColor(out)
@@ -209,7 +218,8 @@ function onCommitList (err, list) {
 
     list = list.map(commitToOutput)
 
-    printCommits(list)
+    if( !quiet )
+      printCommits(list)
   })
 }
 
@@ -221,7 +231,13 @@ var _startrefcmd = replace(refcmd, { ref: argv['start-ref'] || defaultRef })
   , _gitcmd      = replace(gitcmd, { sincecmd: _sincecmd, untilcmd: _untilcmd })
   , child        = spawn('bash', [ '-c', _gitcmd ])
 
-child.stdout.pipe(split2()).pipe(commitStream(ghUser, ghProject)).pipe(list.obj(onCommitList))
+debug('%s', _startrefcmd)
+debug('%s', _endrefcmd)
+debug('%s', _sincecmd)
+debug('%s', _untilcmd)
+debug('%s', _gitcmd)
+
+child.stdout.pipe(split2()).pipe(commitStream(ghId.user, ghId.name)).pipe(list.obj(onCommitList))
 
 child.stderr.pipe(bl(function (err, _data) {
   if (err)
@@ -233,5 +249,5 @@ child.stderr.pipe(bl(function (err, _data) {
 
 child.on('close', function (code) {
   if (code)
-    throw new Error(`git command [${gitcmd}] exited with code ${code}`)
+    throw new Error('git command [' + gitcmd + '] exited with code ' + code)
 })

--- a/commit-stream.js
+++ b/commit-stream.js
@@ -34,7 +34,7 @@ function commitStream (ghUser, ghProject) {
     } else if (m = line.match(/^\s+PR(?:[- ]?URL)?:?\s*(.+)\s*$/i)) {
       commit.prUrl = m[1]
       if (m = commit.prUrl.match(/^\s*#?(\d+)\s*$/))
-        commit.prUrl = `https://github.com/${ghUser}/${ghProject}/pull/${m[1]}`
+        commit.prUrl = 'https://github.com/' + ghUser + '/' + ghProject + '/pull/' + m[1]
       if (m = commit.prUrl.match(/^(https?:\/\/.+\/([^\/]+)\/([^\/]+))\/\w+\/(\d+)$/i)) {
         commit.ghIssue   = +m[4]
         commit.ghUser    = m[2]

--- a/package.json
+++ b/package.json
@@ -16,15 +16,18 @@
     "ghissues": "~1.0.0",
     "list-stream": "~1.0.0",
     "minimist": "~1.1.0",
+    "pkg-to-id": "~0.0.2",
     "split2": "~0.2.1",
     "strip-ansi": "~2.0.1",
     "through2": "~0.6.3",
-    "tsml": "~1.0.0"
+    "debug": "~2.2.0"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/rvagg/changelog-maker.git"
   },
   "preferGlobal": true,
-  "scripts": {}
+  "scripts": {
+    "lint": "jshint ./*js"
+  }
 }


### PR DESCRIPTION
…fallback to default built in.

Change git history search to look for patterns `v*.*.*` or `*.*.*` or `all commits`.
Remove io.js compatibility warning.
Remove tsml dependency, adds pkg-to-id, debug.
Add lint script (jshint).
Improve git log parsing, summary was sometimes undefined.
Add cli options
* `--quiet` do not print to process.stdout
* `--all process` all commits since beginning, instead of last tag
* `--simple` will print a simple form, without additional Markdown cruft