### PR TITLE
Add -h|--help argument. It displays `Usage` section from the README

### DIFF
--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -11,7 +11,6 @@ const spawn    = require('child_process').spawn
     , ghissues = require('ghissues')
     , chalk    = require('chalk')
     , pkgtoId  = require('pkg-to-id')
-    , mdExtract= require('markdown-extract')
     , commitStream = require('./commit-stream')
 
     , argv     = require('minimist')(process.argv.slice(2))
@@ -38,10 +37,7 @@ const spawn    = require('child_process').spawn
       }
 
 if (needHelp) {
-  console.log(
-    mdExtract ({type: /heading/, text: /Usage/, gnp: true})
-      .join('\n').replace(/`/g, '').replace(/[*]{2}/g, '')
-  )
+  showUsage()
   process.exit(0)
 }
 
@@ -62,6 +58,13 @@ function replace (s, m) {
   return s
 }
 
+function showUsage(){
+  var usage = fs.readFileSync("README.md", "utf8")
+    .replace(/[\s\S]+## Usage\n([\s\S]*)\n## [\s\S]+/m, "$1")
+    .replace(/\*\*/g, "")
+    .replace(/`/g, "")
+  process.stdout.write(usage)
+}
 
 function organiseCommits (list) {
   if (argv['start-ref'])

--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -11,6 +11,7 @@ const spawn    = require('child_process').spawn
     , ghissues = require('ghissues')
     , chalk    = require('chalk')
     , pkgtoId  = require('pkg-to-id')
+    , mdExtract= require('markdown-extract')
     , commitStream = require('./commit-stream')
 
     , argv     = require('minimist')(process.argv.slice(2))
@@ -19,6 +20,8 @@ const spawn    = require('child_process').spawn
 
     , pkg      = require('./package.json')
     , debug    = require('debug')(pkg.name)
+
+    , needHelp = argv.h || argv.help
 
     , cwd      = process.cwd()
     , pkgFile  = path.join(cwd, 'package.json')
@@ -33,6 +36,14 @@ const spawn    = require('child_process').spawn
           configName : 'changelog-maker'
         , scopes     : ['repo']
       }
+
+if (needHelp) {
+  console.log(
+    mdExtract ({type: /heading/, text: /Usage/, gnp: true})
+      .join('\n').replace(/`/g, '').replace(/[*]{2}/g, '')
+  )
+  process.exit(0)
+}
 
 const gitcmd        = 'git log --pretty=full --since="{{sincecmd}}" --until="{{untilcmd}}"'
     , commitdatecmd = '$(git show -s --format=%cd `{{refcmd}}`)'

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
     "after": "~0.8.1",
     "bl": "~0.9.4",
     "chalk": "~0.5.1",
+    "debug": "~2.2.0",
     "ghauth": "~2.0.0",
     "ghissues": "~1.0.0",
     "list-stream": "~1.0.0",
+    "markdown-extract": "^1.0.0",
     "minimist": "~1.1.0",
     "pkg-to-id": "~0.0.2",
     "split2": "~0.2.1",
     "strip-ansi": "~2.0.1",
-    "through2": "~0.6.3",
-    "debug": "~2.2.0"
+    "through2": "~0.6.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "ghauth": "~2.0.0",
     "ghissues": "~1.0.0",
     "list-stream": "~1.0.0",
-    "markdown-extract": "^1.0.0",
     "minimist": "~1.1.0",
     "pkg-to-id": "~0.0.2",
     "split2": "~0.2.1",


### PR DESCRIPTION
Add dependency to `markdown-extract`

fix #10