### PR TITLE
Don't fail when running for nodejs/node

### DIFF
--- a/changelog-maker.js
+++ b/changelog-maker.js
@@ -41,7 +41,7 @@ const gitcmd         = 'git log --pretty=full --since="{{sincecmd}}" --until="{{
 debug(ghId)
 
 function stripScope (name) {
-  return name[0] === '@' && name.indexOf('/') > 0 ? name.split('/')[1] : name
+  return name && name[0] === '@' && name.indexOf('/') > 0 ? name.split('/')[1] : name
 }
 
 function replace (s, m) {


### PR DESCRIPTION
When `name` is passed to stripScope, it could be falsy

Fixes: #30