### PR TITLE
rate limit the requests to github

### DIFF
--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -1,6 +1,6 @@
 const ghauth         = require('ghauth')
     , ghissues       = require('ghissues')
-    , after          = require('after')
+    , async          = require('async')
 
     , authOptions    = {
           configName : 'changelog-maker'
@@ -19,26 +19,25 @@ function collectCommitLabels (list, callback) {
   ghauth(authOptions, function (err, authData) {
     if (err)
       return callback(err)
-
-    var done = after(sublist.length, callback)
-
-    sublist.forEach(function (commit) {
+    var q = async.queue(function (commit, next) {
       function onFetch (err, issue) {
         if (err) {
           console.error('Error fetching issue #%s: %s', commit.ghIssue, err.message );
-          return done()
+          return next()
         }
 
         if (issue.labels)
           commit.labels = issue.labels.map(function (label) { return label.name })
-        done()
+        next()
       }
 
       if (commit.ghUser == 'iojs')
         commit.ghUser = 'nodejs' // forcably rewrite as the GH API doesn't do it for us
 
       ghissues.get(authData, commit.ghUser, commit.ghProject, commit.ghIssue, onFetch)
-    })
+    }, 15)
+    q.drain = callback
+    q.push(sublist)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "MIT",
   "dependencies": {
-    "after": "~0.8.1",
+    "async": "^2.0.1",
     "bl": "~1.0.0",
     "chalk": "~1.1.1",
     "commit-stream": "~1.0.1",


### PR DESCRIPTION
github has implemented a new ddos protection method that is causing
consistent failures and timeouts when making more than 50 requests.

This change introduces async and uses its queue functionality and
some setTimeouts with magic numbers to force a rate limit on the
network requests, the result seems to potentially be an overall faster
experience for lower numbers of changes being compared.

Currently async is queuing 15 items and applying a 30ms delay for
callbacks. These numbers could be tunes or potentially exposed as
variables.