### PR TITLE
escape <> in markdown

### DIFF
--- a/commit-to-output.js
+++ b/commit-to-output.js
@@ -4,8 +4,8 @@ const chalk   = require('chalk')
 
 
 function cleanMarkdown (txt) {
-  // just escape '[' & ']'
-  return txt.replace(/([\[\]])/g, '\\$1')
+  // escape []<>
+  return txt.replace(/([\[\]<>])/g, '\\$1')
 }
 
 


### PR DESCRIPTION
Fixes: https://github.com/rvagg/changelog-maker/issues/43

/R=@silverwind 