### PR TITLE
Implement simple cache for issue lookup

### DIFF
--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -36,22 +36,16 @@ function collectCommitLabels (list, callback) {
       if (commit.ghUser == 'iojs')
         commit.ghUser = 'nodejs' // forcably rewrite as the GH API doesn't do it for us
 
-      const promise = cache[commit.ghIssue] || new Promise((resolve, reject) => {
+      // To prevent multiple simultaneous requests for the same issue
+      // from hitting the network at the same time, immediately assign a Promise
+      // to the cache that all commits with the same ghIssue value will use.
+      cache[commit.ghIssue] = cache[commit.ghIssue] || new Promise((resolve, reject) => {
         ghissues.get(authData, commit.ghUser, commit.ghProject, commit.ghIssue, (err, issue) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(issue)
-          }
+          if (err) return reject(err)
+          resolve(issue)
         })
       })
-      cache[commit.ghIssue] = promise
-      promise
-        .then(val => {
-          onFetch(null, val)
-        }, err => {
-          onFetch(err)
-        })
+      cache[commit.ghIssue].then(val => onFetch(null, val), err => onFetch(err))
     }, 15)
     q.drain = callback
     q.push(sublist)

--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -36,15 +36,22 @@ function collectCommitLabels (list, callback) {
       if (commit.ghUser == 'iojs')
         commit.ghUser = 'nodejs' // forcably rewrite as the GH API doesn't do it for us
 
-      if (cache[commit.ghIssue]) {
-        onFetch(null, cache[commit.ghIssue])
-      } else {
+      const promise = cache[commit.ghIssue] || new Promise((resolve, reject) => {
         ghissues.get(authData, commit.ghUser, commit.ghProject, commit.ghIssue, (err, issue) => {
-          if (err) return onFetch(err)
-          cache[commit.ghIssue] = issue
-          onFetch(null, issue)
+          if (err) {
+            reject(err)
+          } else {
+            resolve(issue)
+          }
         })
-      }
+      })
+      cache[commit.ghIssue] = promise
+      promise
+        .then(val => {
+          onFetch(null, val)
+        }, err => {
+          onFetch(err)
+        })
     }, 15)
     q.drain = callback
     q.push(sublist)

--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -8,10 +8,6 @@ const ghauth         = require('ghauth')
       }
 
 
-function cacheKey(commit) {
-  return `${commit.ghUser}/${commit.ghProject}#${commit.ghIssue}`
-}
-
 function collectCommitLabels (list, callback) {
   var sublist = list.filter(function (commit) {
     return typeof commit.ghIssue == 'number' && commit.ghUser && commit.ghProject
@@ -43,7 +39,7 @@ function collectCommitLabels (list, callback) {
       // To prevent multiple simultaneous requests for the same issue
       // from hitting the network at the same time, immediately assign a Promise
       // to the cache that all commits with the same ghIssue value will use.
-      const key = cacheKey(commit)
+      const key = `${commit.ghUser}/${commit.ghProject}#${commit.ghIssue}`
       cache[key] = cache[key] || new Promise((resolve, reject) => {
         ghissues.get(authData, commit.ghUser, commit.ghProject, commit.ghIssue, (err, issue) => {
           if (err) return reject(err)

--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -43,13 +43,14 @@ function collectCommitLabels (list, callback) {
       // To prevent multiple simultaneous requests for the same issue
       // from hitting the network at the same time, immediately assign a Promise
       // to the cache that all commits with the same ghIssue value will use.
-      cache[cacheKey(commit)] = cache[cacheKey(commit)] || new Promise((resolve, reject) => {
+      const key = cacheKey(commit)
+      cache[key] = cache[key] || new Promise((resolve, reject) => {
         ghissues.get(authData, commit.ghUser, commit.ghProject, commit.ghIssue, (err, issue) => {
           if (err) return reject(err)
           resolve(issue)
         })
       })
-      cache[cacheKey(commit)].then(val => onFetch(null, val), err => onFetch(err))
+      cache[key].then(val => onFetch(null, val), err => onFetch(err))
     }, 15)
     q.drain = callback
     q.push(sublist)

--- a/collect-commit-labels.js
+++ b/collect-commit-labels.js
@@ -36,22 +36,15 @@ function collectCommitLabels (list, callback) {
       if (commit.ghUser == 'iojs')
         commit.ghUser = 'nodejs' // forcably rewrite as the GH API doesn't do it for us
 
-      const promise = cache[commit.ghIssue] || new Promise((resolve, reject) => {
+      if (cache[commit.ghIssue]) {
+        onFetch(null, cache[commit.ghIssue])
+      } else {
         ghissues.get(authData, commit.ghUser, commit.ghProject, commit.ghIssue, (err, issue) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(issue)
-          }
+          if (err) return onFetch(err)
+          cache[commit.ghIssue] = issue
+          onFetch(null, issue)
         })
-      })
-      cache[commit.ghIssue] = promise
-      promise
-        .then(val => {
-          onFetch(null, val)
-        }, err => {
-          onFetch(err)
-        })
+      }
     }, 15)
     q.drain = callback
     q.push(sublist)


### PR DESCRIPTION
`collect-commit-labels.js` looks up issues from GitHub via the API with no caching; this makes it easy to accidentally trigger GitHub's abuse detection mechanisms when a single issue is fetched more than once.

This adds a very simple caching layer to the file, ensuring that each issue is only fetched at most one time. It doesn't persist over multiple runs of the tool — if desired, this could be added in a new PR.

/cc @MylesBorins 